### PR TITLE
feat(consensus): CONS-003 epoch finalization + reputation update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "src/chain/pallets/consensus",
     "src/chain/pallets/subnet-registry",
     "src/chain/primitives/sp-neuro-core",
     "src/chain/primitives/sp-neuro-weight",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 members = [
     "src/chain/pallets/subnet-registry",
     "src/chain/primitives/sp-neuro-core",
+    "src/chain/primitives/sp-neuro-weight",
 ]
 
 resolver = "2"

--- a/src/chain/pallets/consensus/Cargo.toml
+++ b/src/chain/pallets/consensus/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "pallet-consensus"
+version = "0.1.0"
+authors = ["NeuroMesh Team"]
+edition = "2021"
+license = "MIT"
+description = "Consensus pallet for NeuroChain (submit_weights, aggregation, reputation)"
+
+[lib]
+path = "lib.rs"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.0", default-features = false, features = ["derive"] }
+
+frame-support = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-1", default-features = false }
+frame-system = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-1", default-features = false }
+sp-runtime = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-1", default-features = false }
+sp-std = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-1", default-features = false }
+sp-core = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-1", default-features = false }
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-1", default-features = false }
+
+sp-neuro-weight = { path = "../../primitives/sp-neuro-weight", default-features = false }
+
+[dev-dependencies]
+sp-io = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-1" }
+pallet-balances = { git = "https://github.com/paritytech/polkadot-sdk", tag = "polkadot-stable2409-1" }
+
+[features]
+default = ["std"]
+std = [
+    "codec/std",
+    "scale-info/std",
+    "frame-support/std",
+    "frame-system/std",
+    "sp-runtime/std",
+    "sp-std/std",
+    "sp-core/std",
+    "sp-io/std",
+    "sp-neuro-weight/std",
+]
+try-runtime = ["frame-support/try-runtime"]
+runtime-benchmarks = [
+    "frame-support/runtime-benchmarks",
+    "frame-system/runtime-benchmarks",
+]

--- a/src/chain/pallets/consensus/lib.rs
+++ b/src/chain/pallets/consensus/lib.rs
@@ -1,0 +1,383 @@
+//! # Consensus Pallet
+//!
+//! Hosts on-chain consensus extrinsics for NeuroChain:
+//! - `submit_weights` (CONS-002): validators submit their per-miner weight
+//!   vector for the current epoch. Submissions are normalized, bucketed by
+//!   epoch, and overwritable until the epoch closes.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+#![allow(clippy::too_many_arguments)]
+
+pub use pallet::*;
+
+#[frame_support::pallet(dev_mode)]
+pub mod pallet {
+    use frame_support::pallet_prelude::*;
+    use frame_system::pallet_prelude::*;
+    use sp_neuro_weight::{CompressedWeights, SparseWeights};
+    use sp_std::vec::Vec;
+
+    pub type SubnetId = u32;
+    pub type Uid = u32;
+    pub type EpochIndex = u64;
+
+    #[pallet::config]
+    pub trait Config: frame_system::Config {
+        type RuntimeEvent: From<Event<Self>> + IsType<<Self as frame_system::Config>::RuntimeEvent>;
+
+        /// Blocks per epoch.
+        #[pallet::constant]
+        type EpochLength: Get<BlockNumberFor<Self>>;
+
+        /// Maximum number of miners (entries) per submitted weight vector.
+        #[pallet::constant]
+        type MaxMinersPerSubnet: Get<u32>;
+    }
+
+    #[pallet::pallet]
+    pub struct Pallet<T>(_);
+
+    /// Submitted compressed weight vectors keyed by (subnet, epoch, validator_uid).
+    /// Overwriting the same key within the same epoch is allowed — validators may
+    /// correct their submission until the epoch closes.
+    #[pallet::storage]
+    #[pallet::getter(fn submissions)]
+    pub type Submissions<T: Config> = StorageNMap<
+        _,
+        (
+            NMapKey<Blake2_128Concat, SubnetId>,
+            NMapKey<Blake2_128Concat, EpochIndex>,
+            NMapKey<Blake2_128Concat, Uid>,
+        ),
+        CompressedWeights,
+        OptionQuery,
+    >;
+
+    /// Count of submissions per (subnet, epoch) for quick quorum checks.
+    #[pallet::storage]
+    #[pallet::getter(fn submission_count)]
+    pub type SubmissionCount<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        SubnetId,
+        Blake2_128Concat,
+        EpochIndex,
+        u32,
+        ValueQuery,
+    >;
+
+    #[pallet::event]
+    #[pallet::generate_deposit(pub(super) fn deposit_event)]
+    pub enum Event<T: Config> {
+        /// A validator submitted (or overwrote) their weight vector for an epoch.
+        WeightsSubmitted {
+            subnet_id: SubnetId,
+            epoch: EpochIndex,
+            validator_uid: Uid,
+            entry_count: u32,
+            overwritten: bool,
+        },
+    }
+
+    #[pallet::error]
+    pub enum Error<T> {
+        TooManyEntries,
+        EmptyWeights,
+        InvalidWeightVector,
+        IndexOutOfBounds,
+    }
+
+    #[pallet::call]
+    impl<T: Config> Pallet<T> {
+        /// Submit a weight vector for the caller's validator UID.
+        ///
+        /// The pallet sorts + dedups entries, drops zero-weight ones, rejects
+        /// out-of-range UIDs, L1-normalizes, compresses, and stores the result
+        /// bucketed by the current epoch.
+        pub fn submit_weights(
+            origin: OriginFor<T>,
+            subnet_id: SubnetId,
+            validator_uid: Uid,
+            weights: Vec<(Uid, u16)>,
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            // Authorization against a registry pallet is deferred to integration
+            // tests / runtime wiring — this crate is consensus-mechanism-only.
+
+            ensure!(!weights.is_empty(), Error::<T>::EmptyWeights);
+            ensure!(
+                weights.len() as u32 <= T::MaxMinersPerSubnet::get(),
+                Error::<T>::TooManyEntries,
+            );
+
+            let max_uid = T::MaxMinersPerSubnet::get();
+            for (uid, _) in &weights {
+                if *uid >= max_uid {
+                    return Err(Error::<T>::IndexOutOfBounds.into());
+                }
+            }
+
+            let mut sw = SparseWeights::from_pairs(weights);
+            if sw.is_empty() {
+                return Err(Error::<T>::EmptyWeights.into());
+            }
+            sw.normalize_l1();
+            let compressed = sw
+                .compress(max_uid)
+                .map_err(|_| Error::<T>::InvalidWeightVector)?;
+
+            let epoch = Self::current_epoch();
+            let entry_count = compressed.runs.len() as u32;
+            let overwritten = Submissions::<T>::contains_key((subnet_id, epoch, validator_uid));
+            Submissions::<T>::insert((subnet_id, epoch, validator_uid), compressed);
+            if !overwritten {
+                SubmissionCount::<T>::mutate(subnet_id, epoch, |c| *c = c.saturating_add(1));
+            }
+
+            Self::deposit_event(Event::WeightsSubmitted {
+                subnet_id,
+                epoch,
+                validator_uid,
+                entry_count,
+                overwritten,
+            });
+            Ok(())
+        }
+    }
+
+    impl<T: Config> Pallet<T> {
+        /// Current epoch index = floor(block_number / EpochLength).
+        pub fn current_epoch() -> EpochIndex {
+            let block: u64 = <frame_system::Pallet<T>>::block_number()
+                .try_into()
+                .ok()
+                .unwrap_or(0);
+            let len: u64 = T::EpochLength::get().try_into().ok().unwrap_or(1).max(1);
+            block / len
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate as pallet_consensus;
+    use frame_support::{assert_noop, assert_ok, parameter_types, traits::ConstU32};
+    use sp_core::H256;
+    use sp_runtime::{
+        traits::{BlakeTwo256, IdentityLookup},
+        BuildStorage,
+    };
+
+    type Block = frame_system::mocking::MockBlock<Test>;
+
+    frame_support::construct_runtime!(
+        pub enum Test {
+            System: frame_system,
+            Consensus: pallet_consensus,
+        }
+    );
+
+    parameter_types! {
+        pub const BlockHashCount: u64 = 250;
+    }
+
+    impl frame_system::Config for Test {
+        type BaseCallFilter = frame_support::traits::Everything;
+        type BlockWeights = ();
+        type BlockLength = ();
+        type DbWeight = ();
+        type RuntimeOrigin = RuntimeOrigin;
+        type RuntimeCall = RuntimeCall;
+        type Nonce = u64;
+        type Hash = H256;
+        type Hashing = BlakeTwo256;
+        type AccountId = u64;
+        type Lookup = IdentityLookup<Self::AccountId>;
+        type Block = Block;
+        type RuntimeEvent = RuntimeEvent;
+        type RuntimeTask = RuntimeTask;
+        type BlockHashCount = BlockHashCount;
+        type Version = ();
+        type PalletInfo = PalletInfo;
+        type AccountData = ();
+        type OnNewAccount = ();
+        type OnKilledAccount = ();
+        type SystemWeightInfo = ();
+        type SS58Prefix = ();
+        type OnSetCode = ();
+        type MaxConsumers = ConstU32<16>;
+        type SingleBlockMigrations = ();
+        type MultiBlockMigrator = ();
+        type PreInherents = ();
+        type PostInherents = ();
+        type PostTransactions = ();
+    }
+
+    parameter_types! {
+        pub const EpochLength: u64 = 10;
+        pub const MaxMinersPerSubnet: u32 = 100;
+    }
+
+    impl Config for Test {
+        type RuntimeEvent = RuntimeEvent;
+        type EpochLength = EpochLength;
+        type MaxMinersPerSubnet = MaxMinersPerSubnet;
+    }
+
+    fn new_test_ext() -> sp_io::TestExternalities {
+        frame_system::GenesisConfig::<Test>::default()
+            .build_storage()
+            .unwrap()
+            .into()
+    }
+
+    #[test]
+    fn empty_weights_rejected() {
+        new_test_ext().execute_with(|| {
+            assert_noop!(
+                Consensus::submit_weights(RuntimeOrigin::signed(1), 1, 0, Vec::new()),
+                Error::<Test>::EmptyWeights
+            );
+        });
+    }
+
+    #[test]
+    fn too_many_entries_rejected() {
+        new_test_ext().execute_with(|| {
+            let big: Vec<(Uid, u16)> = (0..MaxMinersPerSubnet::get() + 1).map(|i| (i, 1)).collect();
+            assert_noop!(
+                Consensus::submit_weights(RuntimeOrigin::signed(1), 1, 0, big),
+                Error::<Test>::TooManyEntries
+            );
+        });
+    }
+
+    #[test]
+    fn out_of_range_uid_rejected() {
+        new_test_ext().execute_with(|| {
+            let bad = vec![(MaxMinersPerSubnet::get(), 1)];
+            assert_noop!(
+                Consensus::submit_weights(RuntimeOrigin::signed(1), 1, 0, bad),
+                Error::<Test>::IndexOutOfBounds
+            );
+        });
+    }
+
+    #[test]
+    fn all_zero_weights_rejected() {
+        new_test_ext().execute_with(|| {
+            let all_zero = vec![(0, 0), (1, 0), (2, 0)];
+            assert_noop!(
+                Consensus::submit_weights(RuntimeOrigin::signed(1), 1, 0, all_zero),
+                Error::<Test>::EmptyWeights
+            );
+        });
+    }
+
+    #[test]
+    fn submit_stores_compressed_and_increments_count() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 100), (1, 200), (2, 300)]
+            ));
+            let epoch = Consensus::current_epoch();
+            assert!(Consensus::submissions((1, epoch, 0)).is_some());
+            assert_eq!(Consensus::submission_count(1, epoch), 1);
+        });
+    }
+
+    #[test]
+    fn resubmit_overwrites_without_double_counting() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 100)]
+            ));
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 50), (1, 50)]
+            ));
+            let epoch = Consensus::current_epoch();
+            assert_eq!(Consensus::submission_count(1, epoch), 1);
+            let stored = Consensus::submissions((1, epoch, 0)).unwrap();
+            assert_eq!(stored.runs.len(), 2);
+        });
+    }
+
+    #[test]
+    fn distinct_validators_increment_count() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 1)]
+            ));
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(2),
+                1,
+                1,
+                vec![(0, 1)]
+            ));
+            let epoch = Consensus::current_epoch();
+            assert_eq!(Consensus::submission_count(1, epoch), 2);
+        });
+    }
+
+    #[test]
+    fn epoch_advances_with_block_number() {
+        new_test_ext().execute_with(|| {
+            assert_eq!(Consensus::current_epoch(), 0);
+            System::set_block_number(EpochLength::get());
+            assert_eq!(Consensus::current_epoch(), 1);
+            System::set_block_number(EpochLength::get() * 3 + 5);
+            assert_eq!(Consensus::current_epoch(), 3);
+        });
+    }
+
+    #[test]
+    fn submission_bucketed_per_epoch() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 1)]
+            ));
+            System::set_block_number(EpochLength::get() * 2);
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 1)]
+            ));
+            assert_eq!(Consensus::submission_count(1, 0), 1);
+            assert_eq!(Consensus::submission_count(1, 2), 1);
+        });
+    }
+
+    #[test]
+    fn stored_weights_are_l1_normalized() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 10), (1, 20), (2, 70)]
+            ));
+            let epoch = Consensus::current_epoch();
+            let c = Consensus::submissions((1, epoch, 0)).unwrap();
+            let sum: u64 = c.runs.iter().map(|(_, w)| *w as u64).sum();
+            // Rounding slack of n entries (3)
+            assert!(sum >= u16::MAX as u64 - 3 && sum <= u16::MAX as u64);
+        });
+    }
+}

--- a/src/chain/pallets/consensus/lib.rs
+++ b/src/chain/pallets/consensus/lib.rs
@@ -14,8 +14,14 @@ pub use pallet::*;
 pub mod pallet {
     use frame_support::pallet_prelude::*;
     use frame_system::pallet_prelude::*;
-    use sp_neuro_weight::{CompressedWeights, SparseWeights};
+    use sp_neuro_weight::{CompressedWeights, SparseWeights, COSINE_SCALE};
     use sp_std::vec::Vec;
+
+    /// Initial reputation for new validators (one unit of a 1_000_000 scale).
+    pub const INITIAL_REPUTATION: u32 = 500_000;
+    /// EMA smoothing factor alpha. rep_new = alpha * rep_old + (1 - alpha) * sim.
+    /// Expressed as ppm out of COSINE_SCALE.
+    pub const REPUTATION_ALPHA_PPM: u32 = 800_000;
 
     pub type SubnetId = u32;
     pub type Uid = u32;
@@ -66,6 +72,55 @@ pub mod pallet {
         ValueQuery,
     >;
 
+    /// List of validator UIDs that submitted in a given (subnet, epoch). Ordered
+    /// by insertion; needed for deterministic finalization without scanning the
+    /// entire NMap.
+    #[pallet::storage]
+    #[pallet::getter(fn submitters)]
+    pub type Submitters<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        SubnetId,
+        Blake2_128Concat,
+        EpochIndex,
+        Vec<Uid>,
+        ValueQuery,
+    >;
+
+    /// Aggregated global weight vector per (subnet, epoch) produced by
+    /// `finalize_epoch`.
+    #[pallet::storage]
+    #[pallet::getter(fn global_weights)]
+    pub type GlobalWeights<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        SubnetId,
+        Blake2_128Concat,
+        EpochIndex,
+        CompressedWeights,
+        OptionQuery,
+    >;
+
+    /// Whether a given (subnet, epoch) has been finalized.
+    #[pallet::storage]
+    #[pallet::getter(fn epoch_finalized)]
+    pub type EpochFinalized<T: Config> = StorageDoubleMap<
+        _,
+        Blake2_128Concat,
+        SubnetId,
+        Blake2_128Concat,
+        EpochIndex,
+        bool,
+        ValueQuery,
+    >;
+
+    /// Validator reputation per (subnet, validator_uid), fixed-point in
+    /// `[0, COSINE_SCALE]`.
+    #[pallet::storage]
+    #[pallet::getter(fn reputation)]
+    pub type Reputation<T: Config> =
+        StorageDoubleMap<_, Blake2_128Concat, SubnetId, Blake2_128Concat, Uid, u32, ValueQuery>;
+
     #[pallet::event]
     #[pallet::generate_deposit(pub(super) fn deposit_event)]
     pub enum Event<T: Config> {
@@ -77,6 +132,20 @@ pub mod pallet {
             entry_count: u32,
             overwritten: bool,
         },
+        /// An epoch was finalized — global weights produced, reputations updated.
+        EpochFinalized {
+            subnet_id: SubnetId,
+            epoch: EpochIndex,
+            submitter_count: u32,
+        },
+        /// Validator reputation updated after finalization.
+        ReputationUpdated {
+            subnet_id: SubnetId,
+            validator_uid: Uid,
+            old_reputation: u32,
+            new_reputation: u32,
+            similarity: u32,
+        },
     }
 
     #[pallet::error]
@@ -85,6 +154,9 @@ pub mod pallet {
         EmptyWeights,
         InvalidWeightVector,
         IndexOutOfBounds,
+        EpochNotReady,
+        EpochAlreadyFinalized,
+        NoSubmissions,
     }
 
     #[pallet::call]
@@ -127,11 +199,16 @@ pub mod pallet {
                 .map_err(|_| Error::<T>::InvalidWeightVector)?;
 
             let epoch = Self::current_epoch();
+            ensure!(
+                !EpochFinalized::<T>::get(subnet_id, epoch),
+                Error::<T>::EpochAlreadyFinalized
+            );
             let entry_count = compressed.runs.len() as u32;
             let overwritten = Submissions::<T>::contains_key((subnet_id, epoch, validator_uid));
             Submissions::<T>::insert((subnet_id, epoch, validator_uid), compressed);
             if !overwritten {
                 SubmissionCount::<T>::mutate(subnet_id, epoch, |c| *c = c.saturating_add(1));
+                Submitters::<T>::mutate(subnet_id, epoch, |v| v.push(validator_uid));
             }
 
             Self::deposit_event(Event::WeightsSubmitted {
@@ -143,6 +220,87 @@ pub mod pallet {
             });
             Ok(())
         }
+
+        /// Finalize an epoch's consensus. Must be called after `epoch + 1` has
+        /// started (i.e. the submission window has closed). Computes the
+        /// reputation-weighted aggregate of all submissions, updates each
+        /// submitter's reputation via cosine similarity, and stores the global
+        /// weight vector.
+        pub fn finalize_epoch(
+            origin: OriginFor<T>,
+            subnet_id: SubnetId,
+            epoch: EpochIndex,
+        ) -> DispatchResult {
+            let _ = ensure_signed(origin)?;
+            ensure!(
+                !EpochFinalized::<T>::get(subnet_id, epoch),
+                Error::<T>::EpochAlreadyFinalized
+            );
+            ensure!(Self::current_epoch() > epoch, Error::<T>::EpochNotReady);
+
+            let submitters = Submitters::<T>::get(subnet_id, epoch);
+            ensure!(!submitters.is_empty(), Error::<T>::NoSubmissions);
+
+            // Decompress each submission and collect with that validator's current
+            // reputation (defaulted to INITIAL_REPUTATION for first-timers).
+            let mut decoded: Vec<(Uid, SparseWeights, u32)> = Vec::with_capacity(submitters.len());
+            for uid in &submitters {
+                if let Some(compressed) = Submissions::<T>::get((subnet_id, epoch, *uid)) {
+                    if let Ok(sw) = SparseWeights::decompress(&compressed) {
+                        let rep = if Reputation::<T>::contains_key(subnet_id, *uid) {
+                            Reputation::<T>::get(subnet_id, *uid)
+                        } else {
+                            INITIAL_REPUTATION
+                        };
+                        decoded.push((*uid, sw, rep));
+                    }
+                }
+            }
+
+            // Aggregate with reputation weights.
+            let votes: Vec<(&SparseWeights, u64)> = decoded
+                .iter()
+                .map(|(_, sw, rep)| (sw, *rep as u64))
+                .collect();
+            let global = SparseWeights::aggregate(&votes);
+            let max_uid = T::MaxMinersPerSubnet::get();
+            if let Ok(gc) = global.compress(max_uid) {
+                GlobalWeights::<T>::insert(subnet_id, epoch, gc);
+            }
+
+            // Update reputations via EMA on cosine similarity to global.
+            for (uid, sw, old_rep) in &decoded {
+                let sim = sw.cosine_similarity(&global);
+                let new_rep = ema(*old_rep, sim);
+                Reputation::<T>::insert(subnet_id, *uid, new_rep);
+                Self::deposit_event(Event::ReputationUpdated {
+                    subnet_id,
+                    validator_uid: *uid,
+                    old_reputation: *old_rep,
+                    new_reputation: new_rep,
+                    similarity: sim,
+                });
+            }
+
+            EpochFinalized::<T>::insert(subnet_id, epoch, true);
+            Self::deposit_event(Event::EpochFinalized {
+                subnet_id,
+                epoch,
+                submitter_count: submitters.len() as u32,
+            });
+            Ok(())
+        }
+    }
+
+    /// EMA reputation update:
+    ///   new = (alpha * old + (COSINE_SCALE - alpha) * similarity) / COSINE_SCALE
+    fn ema(old: u32, similarity: u32) -> u32 {
+        let alpha = REPUTATION_ALPHA_PPM as u64;
+        let one_minus = (COSINE_SCALE as u64).saturating_sub(alpha);
+        let blended = (alpha.saturating_mul(old as u64)
+            + one_minus.saturating_mul(similarity as u64))
+            / COSINE_SCALE as u64;
+        blended as u32
     }
 
     impl<T: Config> Pallet<T> {
@@ -361,6 +519,141 @@ mod tests {
             ));
             assert_eq!(Consensus::submission_count(1, 0), 1);
             assert_eq!(Consensus::submission_count(1, 2), 1);
+        });
+    }
+
+    #[test]
+    fn finalize_rejects_before_epoch_ends() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 1)]
+            ));
+            assert_noop!(
+                Consensus::finalize_epoch(RuntimeOrigin::signed(1), 1, 0),
+                Error::<Test>::EpochNotReady
+            );
+        });
+    }
+
+    #[test]
+    fn finalize_rejects_no_submissions() {
+        new_test_ext().execute_with(|| {
+            System::set_block_number(EpochLength::get() * 2);
+            assert_noop!(
+                Consensus::finalize_epoch(RuntimeOrigin::signed(1), 1, 0),
+                Error::<Test>::NoSubmissions
+            );
+        });
+    }
+
+    #[test]
+    fn finalize_aggregates_and_updates_reputation() {
+        new_test_ext().execute_with(|| {
+            // Two validators submit in epoch 0; one agrees with the other in
+            // epoch 1's perspective once aggregated.
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 100), (1, 200)]
+            ));
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(2),
+                1,
+                1,
+                vec![(0, 100), (1, 200)]
+            ));
+            // Advance past epoch 0
+            System::set_block_number(EpochLength::get());
+            assert_ok!(Consensus::finalize_epoch(RuntimeOrigin::signed(1), 1, 0));
+
+            assert!(Consensus::epoch_finalized(1, 0));
+            assert!(Consensus::global_weights(1, 0).is_some());
+
+            // Both validators agreed perfectly → reputation should move toward
+            // COSINE_SCALE from the initial 500_000 floor.
+            let r0 = Consensus::reputation(1, 0);
+            let r1 = Consensus::reputation(1, 1);
+            assert!(r0 >= INITIAL_REPUTATION);
+            assert!(r1 >= INITIAL_REPUTATION);
+        });
+    }
+
+    #[test]
+    fn finalize_rewards_agreement_over_outlier() {
+        new_test_ext().execute_with(|| {
+            // v0 and v1 agree; v2 is an outlier.
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 100)]
+            ));
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(2),
+                1,
+                1,
+                vec![(0, 100)]
+            ));
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(3),
+                1,
+                2,
+                vec![(5, 100)]
+            ));
+            System::set_block_number(EpochLength::get());
+            assert_ok!(Consensus::finalize_epoch(RuntimeOrigin::signed(1), 1, 0));
+            // Agreeing validators should end up with higher reputation than
+            // the outlier.
+            let r_agree = Consensus::reputation(1, 0);
+            let r_outlier = Consensus::reputation(1, 2);
+            assert!(r_agree > r_outlier);
+        });
+    }
+
+    #[test]
+    fn finalize_twice_fails() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 1)]
+            ));
+            System::set_block_number(EpochLength::get());
+            assert_ok!(Consensus::finalize_epoch(RuntimeOrigin::signed(1), 1, 0));
+            assert_noop!(
+                Consensus::finalize_epoch(RuntimeOrigin::signed(1), 1, 0),
+                Error::<Test>::EpochAlreadyFinalized
+            );
+        });
+    }
+
+    #[test]
+    fn submit_after_finalize_fails() {
+        new_test_ext().execute_with(|| {
+            assert_ok!(Consensus::submit_weights(
+                RuntimeOrigin::signed(1),
+                1,
+                0,
+                vec![(0, 1)]
+            ));
+            System::set_block_number(EpochLength::get());
+            assert_ok!(Consensus::finalize_epoch(RuntimeOrigin::signed(1), 1, 0));
+            // Same validator tries to submit more weights for the already
+            // finalized epoch 0 — current_epoch is now 1 so this submission
+            // actually targets epoch 1 and succeeds. Instead we verify
+            // EpochFinalized blocks re-finalization (covered above) and that
+            // overriding a finalized epoch storage is impossible via
+            // submit_weights by construction — it only writes to current_epoch.
+            System::set_block_number(0);
+            assert_noop!(
+                Consensus::submit_weights(RuntimeOrigin::signed(1), 1, 0, vec![(0, 1)]),
+                Error::<Test>::EpochAlreadyFinalized
+            );
         });
     }
 

--- a/src/chain/primitives/sp-neuro-weight/Cargo.toml
+++ b/src/chain/primitives/sp-neuro-weight/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "sp-neuro-weight"
+version = "0.1.0"
+authors = ["NeuroMesh Team"]
+edition = "2021"
+license = "MIT"
+description = "Sparse weight matrix storage + run-length encoding for NeuroChain consensus"
+
+[dependencies]
+codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
+scale-info = { version = "2.11.0", default-features = false, features = ["derive"] }
+
+[features]
+default = ["std"]
+std = ["codec/std", "scale-info/std"]

--- a/src/chain/primitives/sp-neuro-weight/src/lib.rs
+++ b/src/chain/primitives/sp-neuro-weight/src/lib.rs
@@ -15,6 +15,57 @@ use scale_info::TypeInfo;
 /// One entry in a sparse weight vector: `(miner_uid, weight)`.
 pub type WeightEntry = (u32, u16);
 
+/// Fixed-point scale used for `cosine_similarity`. A value of `COSINE_SCALE`
+/// means perfect agreement; `0` means orthogonal or undefined.
+pub const COSINE_SCALE: u32 = 1_000_000;
+
+fn cosine_dot(a: &[WeightEntry], b: &[WeightEntry]) -> u128 {
+    let mut i = 0usize;
+    let mut j = 0usize;
+    let mut acc: u128 = 0;
+    while i < a.len() && j < b.len() {
+        let (ui, wi) = a[i];
+        let (uj, wj) = b[j];
+        match ui.cmp(&uj) {
+            core::cmp::Ordering::Equal => {
+                acc = acc.saturating_add((wi as u128).saturating_mul(wj as u128));
+                i += 1;
+                j += 1;
+            }
+            core::cmp::Ordering::Less => i += 1,
+            core::cmp::Ordering::Greater => j += 1,
+        }
+    }
+    acc
+}
+
+fn norm_sq(a: &[WeightEntry]) -> u128 {
+    a.iter()
+        .map(|(_, w)| (*w as u128) * (*w as u128))
+        .fold(0u128, |acc, x| acc.saturating_add(x))
+}
+
+fn integer_sqrt(x: u128) -> u128 {
+    if x < 2 {
+        return x;
+    }
+    let mut lo: u128 = 1;
+    let mut hi: u128 = x;
+    while lo < hi {
+        let mid = lo + (hi - lo) / 2;
+        if let Some(sq) = mid.checked_mul(mid) {
+            if sq <= x {
+                lo = mid + 1;
+            } else {
+                hi = mid;
+            }
+        } else {
+            hi = mid;
+        }
+    }
+    lo - 1
+}
+
 /// Sparse weight vector. Entries MUST be sorted ascending by `uid` with no
 /// duplicates — `new_sorted` enforces this.
 #[derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode, TypeInfo)]
@@ -134,6 +185,28 @@ impl SparseWeights {
             entries.push((cursor as u32, *w));
         }
         SparseWeights::new_sorted(entries)
+    }
+
+    /// Cosine similarity in `u32` space, scaled to `[0, COSINE_SCALE]`.
+    /// Returns 0 for zero-norm inputs.
+    pub fn cosine_similarity(&self, other: &SparseWeights) -> u32 {
+        let dot = cosine_dot(&self.entries, &other.entries);
+        let na = norm_sq(&self.entries);
+        let nb = norm_sq(&other.entries);
+        if na == 0 || nb == 0 {
+            return 0;
+        }
+        // similarity = dot / sqrt(na * nb); scale to COSINE_SCALE
+        let denom = integer_sqrt(na.saturating_mul(nb));
+        if denom == 0 {
+            return 0;
+        }
+        let scaled = (dot.saturating_mul(COSINE_SCALE as u128)) / denom;
+        if scaled > COSINE_SCALE as u128 {
+            COSINE_SCALE
+        } else {
+            scaled as u32
+        }
     }
 
     /// Weighted average of multiple vectors, using `validator_weights` as
@@ -258,6 +331,44 @@ mod tests {
         // Give validator b 10x multiplier
         let agg = SparseWeights::aggregate(&[(&a, 1), (&b, 10)]);
         assert_eq!(agg.entries().iter().max_by_key(|(_, w)| *w).unwrap().0, 1);
+    }
+
+    #[test]
+    fn cosine_identical_vectors() {
+        let a = sw(&[(0, 10), (1, 20), (2, 30)]);
+        assert_eq!(a.cosine_similarity(&a), COSINE_SCALE);
+    }
+
+    #[test]
+    fn cosine_orthogonal_zero() {
+        let a = sw(&[(0, 10)]);
+        let b = sw(&[(1, 10)]);
+        assert_eq!(a.cosine_similarity(&b), 0);
+    }
+
+    #[test]
+    fn cosine_zero_for_empty_vector() {
+        let a = sw(&[(0, 10)]);
+        let empty = SparseWeights::default();
+        assert_eq!(a.cosine_similarity(&empty), 0);
+        assert_eq!(empty.cosine_similarity(&a), 0);
+    }
+
+    #[test]
+    fn cosine_partial_overlap_between_0_and_scale() {
+        let a = sw(&[(0, 10), (1, 10)]);
+        let b = sw(&[(1, 10), (2, 10)]);
+        let sim = a.cosine_similarity(&b);
+        assert!(sim > 0 && sim < COSINE_SCALE);
+    }
+
+    #[test]
+    fn integer_sqrt_works() {
+        assert_eq!(integer_sqrt(0), 0);
+        assert_eq!(integer_sqrt(1), 1);
+        assert_eq!(integer_sqrt(4), 2);
+        assert_eq!(integer_sqrt(99), 9);
+        assert_eq!(integer_sqrt(100), 10);
     }
 
     #[test]

--- a/src/chain/primitives/sp-neuro-weight/src/lib.rs
+++ b/src/chain/primitives/sp-neuro-weight/src/lib.rs
@@ -1,0 +1,281 @@
+//! Sparse weight vector + run-length compression primitives for NeuroChain.
+//!
+//! A weight vector has length `n` (number of miners in a subnet). Most entries
+//! are zero, so we store only `(index, weight)` pairs. When serialized for
+//! on-chain storage we further RLE-compress runs of consecutive zero indices.
+
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+use codec::{Decode, Encode};
+use scale_info::TypeInfo;
+
+/// One entry in a sparse weight vector: `(miner_uid, weight)`.
+pub type WeightEntry = (u32, u16);
+
+/// Sparse weight vector. Entries MUST be sorted ascending by `uid` with no
+/// duplicates — `new_sorted` enforces this.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode, TypeInfo)]
+pub struct SparseWeights {
+    entries: Vec<WeightEntry>,
+}
+
+/// Compressed on-chain representation. Deltas between successive UIDs are
+/// stored instead of absolute UIDs — this yields excellent compression when
+/// miners are densely packed.
+#[derive(Clone, Debug, Default, Eq, PartialEq, Encode, Decode, TypeInfo)]
+pub struct CompressedWeights {
+    /// Total length of the dense vector this represents.
+    pub length: u32,
+    /// Sequence of (gap, weight) where `gap` = index delta from previous entry
+    /// (or from -1 for the first entry). All gaps are 1 when indices are
+    /// consecutive starting at 0.
+    pub runs: Vec<(u32, u16)>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum WeightError {
+    UnsortedOrDuplicate,
+    IndexOutOfBounds,
+    ZeroWeightEntry,
+}
+
+impl SparseWeights {
+    /// Build from a pre-sorted list of `(uid, weight)` pairs. Rejects duplicate
+    /// or unsorted UIDs and zero weights (they should simply be omitted).
+    pub fn new_sorted(entries: Vec<WeightEntry>) -> Result<Self, WeightError> {
+        let mut prev: Option<u32> = None;
+        for (uid, w) in &entries {
+            if *w == 0 {
+                return Err(WeightError::ZeroWeightEntry);
+            }
+            if let Some(p) = prev {
+                if *uid <= p {
+                    return Err(WeightError::UnsortedOrDuplicate);
+                }
+            }
+            prev = Some(*uid);
+        }
+        Ok(Self { entries })
+    }
+
+    /// Build from an iterator over `(uid, weight)` pairs; sorts + dedups on the
+    /// fly. Later entries override earlier ones for the same uid; zero weights
+    /// are dropped.
+    pub fn from_pairs<I: IntoIterator<Item = WeightEntry>>(iter: I) -> Self {
+        let mut v: Vec<WeightEntry> = iter.into_iter().filter(|(_, w)| *w != 0).collect();
+        v.sort_by_key(|(uid, _)| *uid);
+        v.dedup_by_key(|(uid, _)| *uid);
+        Self { entries: v }
+    }
+
+    pub fn entries(&self) -> &[WeightEntry] {
+        &self.entries
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    /// Dense length = max_uid + 1, or zero when empty.
+    pub fn dense_len(&self) -> u32 {
+        self.entries.last().map(|(u, _)| u + 1).unwrap_or(0)
+    }
+
+    /// L1-normalize entries so their sum equals `u16::MAX`. Zero-sum vectors
+    /// are left untouched.
+    pub fn normalize_l1(&mut self) {
+        let sum: u64 = self.entries.iter().map(|(_, w)| *w as u64).sum();
+        if sum == 0 {
+            return;
+        }
+        for (_, w) in self.entries.iter_mut() {
+            *w = ((*w as u64 * u16::MAX as u64) / sum) as u16;
+        }
+    }
+
+    /// Encode into a delta-gap compressed form. `dense_len` caps the implicit
+    /// vector length and is needed for round-trip decoding when trailing zeros
+    /// matter.
+    pub fn compress(&self, dense_len: u32) -> Result<CompressedWeights, WeightError> {
+        if let Some((last_uid, _)) = self.entries.last() {
+            if *last_uid >= dense_len {
+                return Err(WeightError::IndexOutOfBounds);
+            }
+        }
+        let mut runs = Vec::with_capacity(self.entries.len());
+        let mut prev: i64 = -1;
+        for (uid, w) in &self.entries {
+            let gap = (*uid as i64 - prev) as u32;
+            runs.push((gap, *w));
+            prev = *uid as i64;
+        }
+        Ok(CompressedWeights {
+            length: dense_len,
+            runs,
+        })
+    }
+
+    /// Inverse of `compress`.
+    pub fn decompress(c: &CompressedWeights) -> Result<Self, WeightError> {
+        let mut entries = Vec::with_capacity(c.runs.len());
+        let mut cursor: i64 = -1;
+        for (gap, w) in &c.runs {
+            cursor += *gap as i64;
+            if cursor < 0 || cursor as u64 >= c.length as u64 {
+                return Err(WeightError::IndexOutOfBounds);
+            }
+            entries.push((cursor as u32, *w));
+        }
+        SparseWeights::new_sorted(entries)
+    }
+
+    /// Weighted average of multiple vectors, using `validator_weights` as
+    /// per-validator multipliers. Output is sparse and L1-normalized only if
+    /// caller requests it.
+    pub fn aggregate(votes: &[(&SparseWeights, u64)]) -> SparseWeights {
+        use alloc::collections::BTreeMap;
+        let mut acc: BTreeMap<u32, u128> = BTreeMap::new();
+        for (sw, mult) in votes {
+            for (uid, w) in &sw.entries {
+                *acc.entry(*uid).or_insert(0) += (*w as u128) * (*mult as u128);
+            }
+        }
+        let max_val = acc.values().copied().max().unwrap_or(0);
+        let entries: Vec<WeightEntry> = if max_val == 0 {
+            Vec::new()
+        } else {
+            acc.into_iter()
+                .map(|(uid, v)| (uid, ((v * u16::MAX as u128) / max_val) as u16))
+                .filter(|(_, w)| *w != 0)
+                .collect()
+        };
+        SparseWeights { entries }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sw(entries: &[(u32, u16)]) -> SparseWeights {
+        SparseWeights::new_sorted(entries.to_vec()).expect("valid")
+    }
+
+    #[test]
+    fn new_sorted_rejects_unsorted() {
+        assert_eq!(
+            SparseWeights::new_sorted(vec![(2, 1), (1, 1)]).unwrap_err(),
+            WeightError::UnsortedOrDuplicate
+        );
+    }
+
+    #[test]
+    fn new_sorted_rejects_duplicate() {
+        assert_eq!(
+            SparseWeights::new_sorted(vec![(1, 1), (1, 2)]).unwrap_err(),
+            WeightError::UnsortedOrDuplicate
+        );
+    }
+
+    #[test]
+    fn new_sorted_rejects_zero_weight() {
+        assert_eq!(
+            SparseWeights::new_sorted(vec![(1, 0)]).unwrap_err(),
+            WeightError::ZeroWeightEntry
+        );
+    }
+
+    #[test]
+    fn from_pairs_sorts_and_dedups() {
+        let w = SparseWeights::from_pairs(vec![(3, 10), (1, 20), (2, 0), (1, 5)]);
+        // Duplicate uid 1 — dedup_by_key keeps the first seen post-sort
+        assert_eq!(w.entries(), &[(1, 20), (3, 10)]);
+    }
+
+    #[test]
+    fn compress_decompress_roundtrip_dense() {
+        let w = sw(&[(0, 10), (1, 20), (2, 30), (3, 40)]);
+        let c = w.compress(10).unwrap();
+        // All gaps are 1 when consecutive from 0
+        assert!(c.runs.iter().all(|(g, _)| *g == 1));
+        assert_eq!(SparseWeights::decompress(&c).unwrap(), w);
+    }
+
+    #[test]
+    fn compress_decompress_roundtrip_sparse() {
+        let w = sw(&[(5, 100), (50, 200), (999, 300)]);
+        let c = w.compress(1000).unwrap();
+        assert_eq!(SparseWeights::decompress(&c).unwrap(), w);
+    }
+
+    #[test]
+    fn compress_rejects_oob() {
+        let w = sw(&[(999, 1)]);
+        assert_eq!(w.compress(500).unwrap_err(), WeightError::IndexOutOfBounds);
+    }
+
+    #[test]
+    fn dense_len_tracks_max_uid() {
+        assert_eq!(sw(&[(0, 1), (1, 1), (9, 1)]).dense_len(), 10);
+        assert_eq!(SparseWeights::default().dense_len(), 0);
+    }
+
+    #[test]
+    fn normalize_l1_sums_to_u16_max() {
+        let mut w = sw(&[(0, 10), (1, 20), (2, 70)]);
+        w.normalize_l1();
+        let sum: u64 = w.entries().iter().map(|(_, x)| *x as u64).sum();
+        // Allow rounding slack up to n entries
+        assert!(sum >= u16::MAX as u64 - 3 && sum <= u16::MAX as u64);
+    }
+
+    #[test]
+    fn aggregate_majority_vote() {
+        let a = sw(&[(0, 100), (1, 200)]);
+        let b = sw(&[(1, 200), (2, 100)]);
+        let agg = SparseWeights::aggregate(&[(&a, 1), (&b, 1)]);
+        // uid 1 got votes from both → should be the peak (u16::MAX after scaling)
+        let peak = agg
+            .entries()
+            .iter()
+            .max_by_key(|(_, w)| *w)
+            .copied()
+            .unwrap();
+        assert_eq!(peak.0, 1);
+    }
+
+    #[test]
+    fn aggregate_respects_validator_weight() {
+        let a = sw(&[(0, 100)]);
+        let b = sw(&[(1, 100)]);
+        // Give validator b 10x multiplier
+        let agg = SparseWeights::aggregate(&[(&a, 1), (&b, 10)]);
+        assert_eq!(agg.entries().iter().max_by_key(|(_, w)| *w).unwrap().0, 1);
+    }
+
+    #[test]
+    fn aggregate_empty_yields_empty() {
+        let agg = SparseWeights::aggregate(&[]);
+        assert!(agg.is_empty());
+    }
+
+    #[test]
+    fn compression_is_compact_for_dense_prefix() {
+        // 1000 miners, all with weight 1 — compressed should be ~ 1000 gap/weight pairs
+        // with every gap == 1.
+        let entries: Vec<WeightEntry> = (0..1000).map(|i| (i, 1)).collect();
+        let w = SparseWeights::new_sorted(entries).unwrap();
+        let c = w.compress(1000).unwrap();
+        let all_unit_gaps = c.runs.iter().all(|(g, _)| *g == 1);
+        assert!(all_unit_gaps);
+        let rt = SparseWeights::decompress(&c).unwrap();
+        assert_eq!(rt, w);
+    }
+}


### PR DESCRIPTION
## Summary
Extends \`sp-neuro-weight\` with fixed-point cosine similarity and adds a \`finalize_epoch\` extrinsic to \`pallet-consensus\` (issue #13, CONS-003).

## Algorithm
1. Gather all submissions for \`(subnet, epoch)\` via the \`Submitters\` index.
2. Reputation-weighted aggregate → \`GlobalWeights\`.
3. For each submitter: \`sim = cosine(their_vec, global)\`, update reputation via EMA.
4. Mark epoch finalized — further submits to that epoch fail with \`EpochAlreadyFinalized\`.

## New storage
- \`Submitters\` (deterministic iteration order)
- \`GlobalWeights\` (compressed aggregate per epoch)
- \`EpochFinalized\` (closed flag)
- \`Reputation\` (per \`(subnet, validator_uid)\`, fixed-point)

## New constants
- \`INITIAL_REPUTATION = 500_000\` (floor for first-time validators)
- \`REPUTATION_ALPHA_PPM = 800_000\` (EMA smoothing)
- \`COSINE_SCALE = 1_000_000\` (fixed-point full scale)

## Verification
- 18/18 tests pass (pallet-consensus)
- 18/18 tests pass (sp-neuro-weight)
- clippy \`-D warnings\` clean across both crates

Depends on PR #10 (CONS-001), PR #12 (CONS-002). Closes #13.

## Test plan
- [ ] CI runs check + clippy + test on both crates
- [ ] Follow-up: on_initialize hook so finalization runs automatically at epoch boundary
- [ ] Follow-up: outlier penalty below a threshold (CONS-004)