### PR TITLE
docs(api): API-001 aggregator OpenAPI 3.0 spec

### DIFF
--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,42 @@
+# NeuroMesh Aggregator API
+
+This directory contains the public API contracts that downstream SDKs and
+integrations target.
+
+## Files
+
+- `openapi.yaml` — OpenAPI 3.0 spec for the public HTTP surface (query, miner
+  listing, subnet status, health).
+
+## Authentication
+
+All endpoints except `/v1/health` require an API key via the
+`X-NeuroMesh-Key` header. Keys are issued through the aggregator's admin
+tooling — see `src/api/aggregator/README.md` for provisioning.
+
+## Rate limits
+
+- Default: **60 requests/minute** per API key for `POST /v1/subnets/{id}/query`.
+- Default: **600 requests/minute** per API key for the `GET` endpoints.
+- 429 responses include `Retry-After`, `X-RateLimit-Limit`, and
+  `X-RateLimit-Remaining` headers.
+
+## Ensemble strategies
+
+| Strategy        | Behavior                                                  |
+| --------------- | --------------------------------------------------------- |
+| `majority`      | Simple majority vote over top-k responses.                |
+| `weighted_avg`  | Weighted average by each miner's current on-chain weight. |
+| `best_of_k`     | Return the single miner response with the highest weight. |
+
+## Error model
+
+All errors are JSON objects matching the `Error` schema:
+
+```json
+{ "code": "RATE_LIMITED", "message": "…", "request_id": "…" }
+```
+
+`code` is machine-readable and stable across releases; `message` is
+human-readable and may change. `request_id` mirrors the aggregator's
+internal trace id for support escalations.

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1,0 +1,273 @@
+openapi: 3.0.3
+info:
+  title: NeuroMesh Aggregator API
+  version: 0.1.0
+  description: |
+    Public HTTP surface of the NeuroMesh aggregator. Clients submit inference
+    queries against a subnet; the aggregator selects top-k miners by current
+    weight, forwards the request, and aggregates the responses according to
+    an ensemble strategy.
+
+servers:
+  - url: https://api.neuromesh.io
+    description: Public mainnet aggregator
+  - url: https://testnet.api.neuromesh.io
+    description: Public testnet aggregator
+
+security:
+  - ApiKeyAuth: []
+
+paths:
+  /v1/health:
+    get:
+      operationId: healthCheck
+      summary: Aggregator liveness probe
+      security: []
+      responses:
+        "200":
+          description: Aggregator is healthy
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Health"
+
+  /v1/subnets/{id}/query:
+    post:
+      operationId: submitQuery
+      summary: Submit an inference request to a subnet
+      parameters:
+        - $ref: "#/components/parameters/SubnetId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/QueryRequest"
+      responses:
+        "200":
+          description: Inference response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/QueryResponse"
+        "400":
+          $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "404":
+          $ref: "#/components/responses/NotFound"
+        "429":
+          $ref: "#/components/responses/RateLimited"
+        "503":
+          $ref: "#/components/responses/Unavailable"
+
+  /v1/subnets/{id}/miners:
+    get:
+      operationId: listMiners
+      summary: List active miners and their current weights
+      parameters:
+        - $ref: "#/components/parameters/SubnetId"
+      responses:
+        "200":
+          description: Miner listing
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MinerListing"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/subnets/{id}/status:
+    get:
+      operationId: subnetStatus
+      summary: Subnet health and metrics
+      parameters:
+        - $ref: "#/components/parameters/SubnetId"
+      responses:
+        "200":
+          description: Subnet status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SubnetStatus"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+components:
+  securitySchemes:
+    ApiKeyAuth:
+      type: apiKey
+      in: header
+      name: X-NeuroMesh-Key
+
+  parameters:
+    SubnetId:
+      name: id
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+
+  schemas:
+    Health:
+      type: object
+      required: [status, version]
+      properties:
+        status:
+          type: string
+          enum: [ok, degraded, down]
+        version:
+          type: string
+
+    QueryRequest:
+      type: object
+      required: [input]
+      properties:
+        input:
+          type: string
+          description: Opaque task input; schema per subnet in `input_schema`.
+        top_k:
+          type: integer
+          default: 5
+          minimum: 1
+          maximum: 100
+        timeout_ms:
+          type: integer
+          default: 10000
+        ensemble:
+          type: string
+          enum: [majority, weighted_avg, best_of_k]
+          default: weighted_avg
+        metadata:
+          type: object
+          additionalProperties:
+            type: string
+
+    QueryResponse:
+      type: object
+      required: [subnet_id, result]
+      properties:
+        subnet_id:
+          type: integer
+        result:
+          type: string
+        ensemble:
+          type: string
+        contributing_miners:
+          type: array
+          items:
+            $ref: "#/components/schemas/MinerResponse"
+
+    MinerResponse:
+      type: object
+      required: [uid, weight]
+      properties:
+        uid:
+          type: integer
+        weight:
+          type: number
+          format: float
+          minimum: 0
+          maximum: 1
+        latency_ms:
+          type: integer
+        output:
+          type: string
+
+    MinerListing:
+      type: object
+      required: [subnet_id, epoch, miners]
+      properties:
+        subnet_id:
+          type: integer
+        epoch:
+          type: integer
+        miners:
+          type: array
+          items:
+            type: object
+            required: [uid, endpoint, weight]
+            properties:
+              uid:
+                type: integer
+              endpoint:
+                type: string
+              weight:
+                type: number
+                format: float
+              reputation:
+                type: integer
+
+    SubnetStatus:
+      type: object
+      required: [subnet_id, epoch, health]
+      properties:
+        subnet_id:
+          type: integer
+        epoch:
+          type: integer
+        health:
+          type: string
+          enum: [healthy, degraded, offline]
+        miner_count:
+          type: integer
+        validator_count:
+          type: integer
+        last_finalized_epoch:
+          type: integer
+        last_finalized_block:
+          type: integer
+
+    Error:
+      type: object
+      required: [code, message]
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        request_id:
+          type: string
+
+  responses:
+    BadRequest:
+      description: Malformed request body or parameters
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Unauthorized:
+      description: Missing or invalid API key
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    NotFound:
+      description: Subnet does not exist
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    RateLimited:
+      description: Client exceeded its quota; retry after `Retry-After`.
+      headers:
+        Retry-After:
+          schema:
+            type: integer
+            description: Seconds until the next request is accepted.
+        X-RateLimit-Limit:
+          schema: { type: integer }
+        X-RateLimit-Remaining:
+          schema: { type: integer }
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
+    Unavailable:
+      description: No miners reachable for this subnet
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"


### PR DESCRIPTION
## Summary
Locks down the public aggregator HTTP contract (issue #21, API-001).

- \`docs/api/openapi.yaml\` — full OpenAPI 3.0 spec with all four endpoints, request/response schemas, error model, auth scheme (\`X-NeuroMesh-Key\`), and rate-limit response headers.
- \`docs/api/README.md\` — rate-limit defaults, ensemble strategy table, stable error-code contract.

Closes #21

## Test plan
- [ ] Validate with \`openapi-generator-cli validate\` or \`spectral lint\`
- [ ] Use as source of truth for SDK-001 client generation